### PR TITLE
fix(challenge): correct datetime format

### DIFF
--- a/CHALLENGE.md
+++ b/CHALLENGE.md
@@ -42,7 +42,7 @@ You are given a prepared SPA project that was bootstrapped with Create React App
 ![success](.github/success-state.png)
 
 - The tournament name has the heading size `h6`.
-- The `Start` date must be displayed in the format `DD/MM/YYYY, HH:MM:SS` using the `en-GB` locale.
+- The `Start` date must be displayed in the format `DD/MM/YYYY, HH:mm:ss` using the `en-GB` locale.
 - The horizontal and vertical spacing between each tournament must be `24px`.
 - The horizontal spacing between the `EDIT` and `DELETE` button is `8px`.
 


### PR DESCRIPTION
# Summary

Our requested datetime format in the CHALLENGE results in months and fractional seconds being used in the datetime. This corrects it in accordance with momentjs' format string.

# Old

Code:

.format('DD/MM/YYYY, HH:MM:SS')}

From momentjs Docs:

```
M MM	1..12	Month number
S SS SSS ... SSSSSSSSS	0..999999999	Fractional seconds
```

Source and Result:

```
// Source
startDate: "2020-07-02T07:31:46.851Z

// Result
Start: 02/07/2020, 08:07:85
```
![Screenshot 2020-07-02 at 08 44 08](https://user-images.githubusercontent.com/188648/86332032-d0c9be80-bc41-11ea-9314-7fc38cebfde3.png)


# New

.format('DD/MM/YYYY, HH:mm:ss')}

```
H HH	0..23	Hours (24 hour time)
m mm	0..59	Minutes
s ss	0..59	Seconds
```

```
// Source
startDate: "2020-07-02T07:31:46.851Z

// Result
Start:02/07/2020, 08:31:46
```
![Screenshot 2020-07-02 at 08 53 27](https://user-images.githubusercontent.com/188648/86332042-d3c4af00-bc41-11ea-972a-1751f8255b29.png)

Assuming that moment is taking BST into account (+1 hour for BST) the new one is correct.
