### PR TITLE
feat: ignore Windows line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ * text=auto eol=lf


### PR DESCRIPTION
Ignores annoying `^M` line endings when doing `git diff` from changes from candidates using Windows